### PR TITLE
bb-EventRepository

### DIFF
--- a/Quantum_Leap_Zack_Taylor/Data/EventRepository.cs
+++ b/Quantum_Leap_Zack_Taylor/Data/EventRepository.cs
@@ -8,11 +8,6 @@ namespace Quantum_Leap_Zack_Taylor.Data
     class EventRepository
     {
         static List<Event> _listOfEvents = new List<Event>();
-
-        public List<Event> GetAll()
-        {
-            return _listOfEvents;
-        }
         
         public void Add(Event eventToAdd)
         {

--- a/Quantum_Leap_Zack_Taylor/Data/EventRepository.cs
+++ b/Quantum_Leap_Zack_Taylor/Data/EventRepository.cs
@@ -24,8 +24,46 @@ namespace Quantum_Leap_Zack_Taylor.Data
 
         public void PopulateEvents()
         {
-            // add event seed data here with the above add method
-            // then call this method at the top of Program.cs
+            var event1 = new Event()
+            {
+                Date = new DateTime(1877, 8, 17),
+                Location = "Bonita, Arizona",
+                Description = "Billy the Kid's first kill."
+            };
+
+            var event2 = new Event()
+            {
+                Date = new DateTime(1796, 6, 20),
+                Location = "Vienna, Austria",
+                Description = "The first day of summer when Ludwig Von Beethoven contracted typhus, which was the probable cause of his hearing loss."
+            };
+
+            var event3 = new Event()
+            {
+                Date = new DateTime(1815, 6, 18),
+                Location = "Waterloo, Netherlands",
+                Description = "Battle of Waterloo."
+            };
+
+            var event4 = new Event()
+            {
+                Date = new DateTime(1865, 4, 14),
+                Location = "Washington, D.C.",
+                Description = "Assassination of Abraham Lincoln."
+            };
+
+            var event5 = new Event()
+            {
+                Date = new DateTime(1430, 5, 23),
+                Location = "Compiegne, France",
+                Description = "Joan of Arch was captured to be put on trial."
+            };
+
+            _listOfEvents.Add(event1);
+            _listOfEvents.Add(event2);
+            _listOfEvents.Add(event3);
+            _listOfEvents.Add(event4);
+            _listOfEvents.Add(event5);
         }
 
         public Event GetRandomEvent()

--- a/Quantum_Leap_Zack_Taylor/Data/EventRepository.cs
+++ b/Quantum_Leap_Zack_Taylor/Data/EventRepository.cs
@@ -1,0 +1,44 @@
+﻿using Quantum_Leap_Zack_Taylor.LeapComponents;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Quantum_Leap_Zack_Taylor.Data
+{
+    class EventRepository
+    {
+        static List<Event> _listOfEvents = new List<Event>();
+
+        public List<Event> GetAll()
+        {
+            return _listOfEvents;
+        }
+        
+        public void Add(Event eventToAdd)
+        {
+            eventToAdd.Id = Guid.NewGuid();
+            eventToAdd.Date = new DateTime();
+            eventToAdd.IsPutRight = false;
+            _listOfEvents.Add(eventToAdd);
+        }
+
+        public void Remove(Event eventToRemove)
+        {
+            _listOfEvents.Remove(eventToRemove);
+        }
+
+        public void PopulateEvents()
+        {
+            // add event seed data here with the above add method
+            // then call this method at the top of Program.cs
+        }
+
+        public Event GetRandomEvent()
+        {
+            Random rnd = new Random();
+            int index = rnd.Next(_listOfEvents.Count);
+            var randomEvent = _listOfEvents[index];
+            return randomEvent;
+        }
+    }
+}

--- a/Quantum_Leap_Zack_Taylor/LeapComponents/Event.cs
+++ b/Quantum_Leap_Zack_Taylor/LeapComponents/Event.cs
@@ -9,6 +9,7 @@ namespace Quantum_Leap_Zack_Taylor.LeapComponents
         public Guid Id { get; set; }
         public string Location { get; set; }
         public DateTime Date { get; set; }
+        public string Description { get; set; }
         public bool IsPutRight { get; set; }
 
         public void PutEventRight()
@@ -19,8 +20,6 @@ namespace Quantum_Leap_Zack_Taylor.LeapComponents
         public Event()
         {
             Id = Guid.NewGuid();
-            Location = "New Location";
-            Date = new DateTime();
             IsPutRight = false;
         }
     }

--- a/Quantum_Leap_Zack_Taylor/Program.cs
+++ b/Quantum_Leap_Zack_Taylor/Program.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using Quantum_Leap_Zack_Taylor.Data;
+using System;
 
 namespace Quantum_Leap_Zack_Taylor
 {
@@ -6,6 +7,8 @@ namespace Quantum_Leap_Zack_Taylor
     {
         static void Main(string[] args)
         {
+            var eventRepository = new EventRepository();
+            eventRepository.PopulateEvents();
             Console.WriteLine("Hello World!");
         }
     }

--- a/Quantum_Leap_Zack_Taylor/Quantum_Leap_Zack_Taylor.csproj
+++ b/Quantum_Leap_Zack_Taylor/Quantum_Leap_Zack_Taylor.csproj
@@ -5,8 +5,4 @@
     <TargetFramework>netcoreapp2.2</TargetFramework>
   </PropertyGroup>
 
-  <ItemGroup>
-    <Folder Include="Data\" />
-  </ItemGroup>
-
 </Project>


### PR DESCRIPTION
closes #7 

- Add() method created to make it easier to populate seed data
- Remove() method created because C# required it alongside Add() when printing seed data
- PopulateEvents() method created as a place to add seed data
- GetRandomEvent() method works.  It was tested in Program.cs and removed because it's not possible to form a unit test on a random response/return.